### PR TITLE
Fix missing setter method for the Frequency attribute

### DIFF
--- a/model/qd-channel-model.cc
+++ b/model/qd-channel-model.cc
@@ -65,8 +65,9 @@ QdChannelModel::GetTypeId (void)
     .AddAttribute ("Frequency",
                    "The operating Frequency in Hz. This attribute is here "
                    "only for compatibility with ns3::ThreeGppSpectrumPropagationLossModel.",
-                   DoubleValue (), // No setter is needed. Frequency is set resing the QD setup files.
-                   MakeDoubleAccessor (&QdChannelModel::GetFrequency),
+                   DoubleValue (__DBL_MIN__), 
+                   MakeDoubleAccessor (&QdChannelModel::SetFrequency,
+                                       &QdChannelModel::GetFrequency),
                    MakeDoubleChecker<double> ())
     ;
 
@@ -387,6 +388,12 @@ QdChannelModel::GetQdSimTime () const
 {
   NS_LOG_FUNCTION (this);
   return m_totalTimeDuration;
+}
+
+void
+QdChannelModel::SetFrequency (double fc)
+{
+  NS_LOG_FUNCTION (this);
 }
 
 double

--- a/model/qd-channel-model.h
+++ b/model/qd-channel-model.h
@@ -105,10 +105,19 @@ public:
    */
   std::string GetScenario () const;
 
+
+  /**
+   * Just a dummy setter for compatibility reasons.
+   * NOTE: the carrier frequency is imported from the QD input
+   * files. This setter should not be manually used, and it is here
+   * only because attributes are required to have a setter.
+   * 
+   * \param fc the center frequency in Hz
+   */
+  void SetFrequency (double fc);
+
   /**
    * Returns the center frequency
-   * NOTE: the carrier frequency is imported from the QD input
-   * files, thus not setter has been added to this class.
    * 
    * \return the center frequency in Hz
    */
@@ -224,7 +233,9 @@ private:
   Time m_updatePeriod; //!< the channel update period
   uint32_t m_totTimesteps; //!< total number of timesteps for the simulation
   Time m_totalTimeDuration; //!< duration of the simulation
-  double m_frequency; //!< the operating frequency [Hz]
+  double m_frequency; /**< the operating frequency [Hz]. 
+                           This value should NOT be manually set by the user, 
+                           as the frequency is parsed from the channel traces instead. */
   std::vector<Vector3D> m_nodePositionList; //!< initial position of each node
 
   std::map<uint32_t, std::vector<QdInfo>>


### PR DESCRIPTION
See #4.
In the end I was not able to add the check I mentioned in the above discussion, as I could discriminate between the setter call due to the initialization and user manual call, but not between the latter and the call to the setter made by the `mmwave-helper`.. 
I tried to explicitly warn that the added setter is just a dummy in the documentation